### PR TITLE
Add new query button

### DIFF
--- a/app/views/mail_reminders/_form.html.erb
+++ b/app/views/mail_reminders/_form.html.erb
@@ -3,6 +3,7 @@
   <p>
     <%= f.label l(:query) %>
     <%= f.select :query_id, queries_for_options(project.id) %>
+    <%= link_to l(:label_query_new), new_query_path, :class => 'icon icon-add' %>
   </p>
   <p>
     <%= f.label l(:interval) %>:


### PR DESCRIPTION
Add "New query" button, so users can add neq query faster.
New user will also not be lost with empty field.